### PR TITLE
sessions_between_states metric

### DIFF
--- a/lib/metrics-helper.js
+++ b/lib/metrics-helper.js
@@ -294,7 +294,7 @@ var MetricsHelper = Eventable.extend(function(self, im) {
                 ``resume``, and ``show``. Defaults to ``enter``.
             :param string label:
                 The label for the metric. Defaults to
-                ``states_between_$ACTIONFROM_$STATEFROM_$ACTIONTO_$STATETO``
+                ``sessions_between_$ACTIONFROM_$STATEFROM_$ACTIONTO_$STATETO``
                 where ``$ACTION_*`` is the specified action, and ``$STATE_*``
                 is the name of the state with all characters that are not
                 ``a-zA-Z._`` replaced with ``_``.
@@ -304,9 +304,9 @@ var MetricsHelper = Eventable.extend(function(self, im) {
         label = typeof label !== 'undefined'
             ? label
             : self._create_metric_label(
-                'states_between_', from_action, state_from.state) +
+                'sessions_between', from_action, state_from.state) +
               self._create_metric_label('', to_action, state_to.state);
-        var metadata_label = 'time_between_states_metric_' + label;
+        var metadata_label = 'sessions_between_states_metric_' + label;
 
         self.im.on('state:' + from_action, function(e) {
             /* Set counter to zero on state_from */

--- a/lib/metrics-helper.js
+++ b/lib/metrics-helper.js
@@ -267,6 +267,72 @@ var MetricsHelper = Eventable.extend(function(self, im) {
         return self;
     };
 
+    self.add.sessions_between_states = function(state_from, state_to, label) {
+        /**:MetricsHelper.add.sessions_between_states(state_from, state_to, label)
+
+            Adds an average metric that measures the amount of sessions
+            between two state events.
+
+            :param object state_from:
+                The state where counting should start.
+            :param object state_to:
+                The state where counting should end.
+            :param object state_*:
+                The name and action of the state, e.g.
+
+                .. code-block:: javascript
+
+                    {
+                        state: 'states:foo',
+                        action: 'exit'
+                    }
+
+            :param string state_*.state:
+                The name of the state. Required.
+            :param string state_*.action:
+                The state action. Can be one of ``enter``, ``exit``, ``input``,
+                ``resume``, and ``show``. Defaults to ``enter``.
+            :param string label:
+                The label for the metric. Defaults to
+                ``states_between_$ACTIONFROM_$STATEFROM_$ACTIONTO_$STATETO``
+                where ``$ACTION_*`` is the specified action, and ``$STATE_*``
+                is the name of the state with all characters that are not
+                ``a-zA-Z._`` replaced with ``_``.
+        */
+        var from_action = self._validate_state_action(state_from.action);
+        var to_action = self._validate_state_action(state_to.action);
+        label = typeof label !== 'undefined'
+            ? label
+            : self._create_metric_label(
+                'states_between_', from_action, state_from.state) +
+              self._create_metric_label('', to_action, state_to.state);
+        var metadata_label = 'time_between_states_metric_' + label;
+
+        self.im.on('state:' + from_action, function(e) {
+            /* Set counter to zero on state_from */
+            if(e.state.name === state_from.state) {
+                self._set_metadata(
+                    e.state.im.user, metadata_label, 0);
+            }
+        });
+
+        self.im.on('session:new', function(e) {
+            /* Increment sessions counter on new sessions */
+            self._increment_metadata(e.im.user, metadata_label);
+        });
+
+        self.im.on('state:' + to_action, function(e) {
+            /* Fire metric with number of sessions on state_to */
+            if(e.state.name === state_to.state) {
+                var sessions = self._reset_metadata(
+                    e.state.im.user, metadata_label);
+                return e.state.im.metrics.fire.avg(label, sessions);
+            }
+        });
+
+        return self;
+    };
+
     self.add.tracker = function(start_trigger, end_trigger, metrics) {
         /**:MetricsHelper.add.tracker(start_trigger, end_trigger, metrics)
 

--- a/lib/metrics-helper.js
+++ b/lib/metrics-helper.js
@@ -369,6 +369,11 @@ var MetricsHelper = Eventable.extend(function(self, im) {
                 start_trigger, end_trigger, metrics.time_between_states);
         }
 
+        if(metrics.sessions_between_states) {
+            self.add.sessions_between_states(
+                start_trigger, end_trigger, metrics.sessions_between_states);
+        }
+
         return self;
     };
 

--- a/lib/metrics-helper.js
+++ b/lib/metrics-helper.js
@@ -274,9 +274,9 @@ var MetricsHelper = Eventable.extend(function(self, im) {
             between two state events.
 
             :param object state_from:
-                The state where counting should start.
+                The state where session counting should start.
             :param object state_to:
-                The state where counting should end.
+                The state where session counting should end.
             :param object state_*:
                 The name and action of the state, e.g.
 
@@ -356,7 +356,8 @@ var MetricsHelper = Eventable.extend(function(self, im) {
             :param object metrics:
                 The metrics and their labels that should be attached to the
                 given triggers. Of the format ``metric_type: metric_label``.
-                ``metric_type`` can be one of ``time_between_states``. e.g.
+                ``metric_type`` can be one of ``time_between_states``,
+                ``sessions_between_states``. e.g.
 
                 .. code-block:: javascript
 

--- a/lib/metrics-helper.js
+++ b/lib/metrics-helper.js
@@ -271,7 +271,8 @@ var MetricsHelper = Eventable.extend(function(self, im) {
         /**:MetricsHelper.add.sessions_between_states(state_from, state_to, label)
 
             Adds an average metric that measures the amount of sessions
-            between two state events.
+            between two state events. The metric will fire with a value of 1
+            plus the amount of new sessions between the two state events.
 
             :param object state_from:
                 The state where session counting should start.
@@ -309,10 +310,10 @@ var MetricsHelper = Eventable.extend(function(self, im) {
         var metadata_label = 'sessions_between_states_metric_' + label;
 
         self.im.on('state:' + from_action, function(e) {
-            /* Set counter to zero on state_from */
+            /* Set counter to one on state_from */
             if(e.state.name === state_from.state) {
                 self._set_metadata(
-                    e.state.im.user, metadata_label, 0);
+                    e.state.im.user, metadata_label, 1);
             }
         });
 

--- a/test/test_metrics_helper.js
+++ b/test/test_metrics_helper.js
@@ -412,7 +412,10 @@ describe('MetricsHelper', function() {
                     .add.tracker(
                         { state: 'states:test', action: 'enter'},
                         { state: 'states:test2', action: 'exit'},
-                        { time_between_states: 'time_between' });
+                        {
+                            time_between_states: 'time_between',
+                            sessions_between_states: 'sessions_between'
+                        });
             };
         });
 
@@ -425,6 +428,19 @@ describe('MetricsHelper', function() {
                     assert.equal(metrics.agg, 'avg');
                     assert.equal(metrics.values.length, 1);
                     assert.equal(typeof metrics.values[0], 'number');
+                })
+                .run();
+        });
+
+        it('should add a sessions_between_states metric', function() {
+            return tester
+                .inputs('test', null)
+                .check(function(api) {
+                    metrics = api.metrics
+                        .stores['metricsHelper-tester'].sessions_between;
+                    assert.equal(metrics.agg, 'avg');
+                    assert.equal(metrics.values.length, 1);
+                    assert.equal(metrics.values[0], 1);
                 })
                 .run();
         });

--- a/test/test_metrics_helper.js
+++ b/test/test_metrics_helper.js
@@ -368,7 +368,7 @@ describe('MetricsHelper', function() {
                     metrics = api.metrics
                         .stores['metricsHelper-tester'].sessions_between;
                     assert.equal(metrics.agg, 'avg');
-                    assert.equal(metrics.values[0], 2);
+                    assert.equal(metrics.values[0], 3);
                     assert.equal(typeof metrics.values[0], 'number');
                 })
                 .run();
@@ -382,7 +382,7 @@ describe('MetricsHelper', function() {
                         .sessions_between_enter_states_test_enter_states_test2;
                     assert.equal(metrics.agg, 'avg');
                     assert.equal(metrics.values.length, 1);
-                    assert.equal(metrics.values[0], 1);
+                    assert.equal(metrics.values[0], 2);
                 })
                 .run();
         });
@@ -395,8 +395,8 @@ describe('MetricsHelper', function() {
                         .stores['metricsHelper-tester'].sessions_between;
                     assert.equal(metrics.agg, 'avg');
                     assert.equal(metrics.values.length, 2);
-                    assert.equal(metrics.values[0], 1);
-                    assert.equal(metrics.values[1], 1);
+                    assert.equal(metrics.values[0], 2);
+                    assert.equal(metrics.values[1], 2);
                 })
                 .run();
         });
@@ -440,7 +440,7 @@ describe('MetricsHelper', function() {
                         .stores['metricsHelper-tester'].sessions_between;
                     assert.equal(metrics.agg, 'avg');
                     assert.equal(metrics.values.length, 1);
-                    assert.equal(metrics.values[0], 1);
+                    assert.equal(metrics.values[0], 2);
                 })
                 .run();
         });

--- a/test/test_metrics_helper.js
+++ b/test/test_metrics_helper.js
@@ -346,6 +346,64 @@ describe('MetricsHelper', function() {
 
     });
 
+    describe('when there is a sessions_between_states metric', function() {
+        beforeEach(function() {
+            app.init = function() {
+                metricsH = new MetricsHelper(app.im);
+                metricsH
+                    .add.sessions_between_states(
+                        {state: 'states:test', action: 'enter'},
+                        {state: 'states:test2', action: 'exit'},
+                        'sessions_between')
+                    .add.sessions_between_states(
+                        {state: 'states:test'},
+                        {state: 'states:test2'});
+            };
+        });
+
+        it('should fire the metric when the end state is reached', function() {
+            return tester
+                .inputs(null, 'test', null)
+                .check(function(api) {
+                    metrics = api.metrics
+                        .stores['metricsHelper-tester'].sessions_between;
+                    assert.equal(metrics.agg, 'avg');
+                    assert.equal(metrics.values[0], 2);
+                    assert.equal(typeof metrics.values[0], 'number');
+                })
+                .run();
+        });
+
+        it('should trigger both metrics', function() {
+            return tester
+                .inputs(null, 'test')
+                .check(function(api) {
+                    metrics = api.metrics.stores['metricsHelper-tester']
+                        .sessions_between_enter_states_test_enter_states_test2;
+                    assert.equal(metrics.agg, 'avg');
+                    assert.equal(metrics.values.length, 1);
+                    assert.equal(metrics.values[0], 1);
+                })
+                .run();
+        });
+
+        it('should fire the metric for every event', function() {
+            return tester
+                .inputs('test', null, 'test', null)
+                .check(function(api) {
+                    metrics = api.metrics
+                        .stores['metricsHelper-tester'].sessions_between;
+                    assert.equal(metrics.agg, 'avg');
+                    assert.equal(metrics.values.length, 2);
+                    assert.equal(metrics.values[0], 1);
+                    assert.equal(metrics.values[1], 1);
+                })
+                .run();
+        });
+
+    });
+
+
     describe('the tracker function', function() {
         beforeEach(function() {
             app.init = function() {


### PR DESCRIPTION
Similar to sessions_until_state metric, but allows you to specify the state where you start counting sessions.  This will allow you to evaluate specific sections of an app's performance in terms of session count.
